### PR TITLE
Fixed Vulnerability from dependent package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
-    "mocha": "3.1.2",
+    "mocha": "5.2.0",
     "q": "1.4.1",
     "supertest": "2.0.1"
   }


### PR DESCRIPTION
Changing the mocha version to the new release fixes the vulnerability error.